### PR TITLE
Add support for ToF sensor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "VL53L0X"]
-	path = VL53L0X
-	url = https://github.com/bitbank2/VL53L0X
 [submodule "epuck_ros2_cpp/src/vl53l0x"]
 	path = epuck_ros2_cpp/src/vl53l0x
 	url = https://github.com/bitbank2/VL53L0X

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "VL53L0X"]
+	path = VL53L0X
+	url = https://github.com/bitbank2/VL53L0X
+[submodule "epuck_ros2_cpp/src/vl53l0x"]
+	path = epuck_ros2_cpp/src/vl53l0x
+	url = https://github.com/bitbank2/VL53L0X

--- a/epuck_ros2_cpp/CMakeLists.txt
+++ b/epuck_ros2_cpp/CMakeLists.txt
@@ -1,12 +1,10 @@
 cmake_minimum_required(VERSION 3.5)
 project(epuck_ros2_cpp)
 
-# Default to C99
 if(NOT CMAKE_C_STANDARD)
   set(CMAKE_C_STANDARD 99)
 endif()
 
-# Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
@@ -23,8 +21,7 @@ find_package(sensor_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(nav_msgs REQUIRED)
 
-
-add_executable(driver 
+add_executable(driver
   src/driver.cpp
   src/vl53l0x/tof.c
 )
@@ -57,29 +54,27 @@ if(BUILD_TESTING)
   find_package(ament_cmake_pep257 REQUIRED)
   find_package(ament_cmake_xmllint REQUIRED)
   find_package(ament_cmake_clang_format REQUIRED)
-  set(PACKAGE_SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_CURRENT_SOURCE_DIR}/src/driver.cpp")
+  set(PACKAGE_CPP_FILES
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
+  )
 
-  ament_cppcheck()
+  ament_cppcheck(
+    ARGN ${PACKAGE_CPP_FILES}
+  )
   ament_cpplint(
+    ARGN ${PACKAGE_CPP_FILES}
     MAX_LINE_LENGTH 128
   )
   ament_copyright(
-    ARGN ${PACKAGE_SOURCE_FILES}
+    ARGN ${PACKAGE_CPP_FILES}
   )
-  ament_lint_cmake(
-    ARGN ${PACKAGE_SOURCE_FILES}
-  )
-  ament_flake8(
-    ARGN ${PACKAGE_SOURCE_FILES}
-  )
-  ament_pep257(
-    ARGN ${PACKAGE_SOURCE_FILES}
-  )
-  ament_xmllint(
-    ARGN ${PACKAGE_SOURCE_FILES}
-  )
+  ament_lint_cmake()
+  ament_flake8()
+  ament_pep257()
+  ament_xmllint()
   ament_clang_format(
-    ARGN ${PACKAGE_SOURCE_FILES}
+    ARGN ${PACKAGE_CPP_FILES}
     CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../.clang-format"
   )
 

--- a/epuck_ros2_cpp/CMakeLists.txt
+++ b/epuck_ros2_cpp/CMakeLists.txt
@@ -57,17 +57,29 @@ if(BUILD_TESTING)
   find_package(ament_cmake_pep257 REQUIRED)
   find_package(ament_cmake_xmllint REQUIRED)
   find_package(ament_cmake_clang_format REQUIRED)
+  set(PACKAGE_SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_CURRENT_SOURCE_DIR}/src/driver.cpp")
 
   ament_cppcheck()
   ament_cpplint(
     MAX_LINE_LENGTH 128
   )
-  ament_copyright()
-  ament_lint_cmake()
-  ament_flake8()
-  ament_pep257()
-  ament_xmllint()
+  ament_copyright(
+    ARGN ${PACKAGE_SOURCE_FILES}
+  )
+  ament_lint_cmake(
+    ARGN ${PACKAGE_SOURCE_FILES}
+  )
+  ament_flake8(
+    ARGN ${PACKAGE_SOURCE_FILES}
+  )
+  ament_pep257(
+    ARGN ${PACKAGE_SOURCE_FILES}
+  )
+  ament_xmllint(
+    ARGN ${PACKAGE_SOURCE_FILES}
+  )
   ament_clang_format(
+    ARGN ${PACKAGE_SOURCE_FILES}
     CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../.clang-format"
   )
 
@@ -77,6 +89,7 @@ if(BUILD_TESTING)
   # find_package(ament_cmake_uncrustify REQUIRED)
   # ament_uncrustify(
   #   TESTNAME "uncrustify_${PROJECT_NAME}"
+  #   ARGN ${PACKAGE_SOURCE_FILES}
   #   CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../uncrustify.cfg"
   #   MAX_LINE_LENGTH 128
   #   "${_output_path}"

--- a/epuck_ros2_cpp/CMakeLists.txt
+++ b/epuck_ros2_cpp/CMakeLists.txt
@@ -24,10 +24,15 @@ find_package(tf2_ros REQUIRED)
 find_package(nav_msgs REQUIRED)
 
 
-add_executable(driver src/driver.cpp)
+add_executable(driver 
+  src/driver.cpp
+  src/vl53l0x/tof.c
+)
 target_include_directories(driver PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
+  $<INSTALL_INTERFACE:include>
+  src/vl53l0x
+)
 
 ament_target_dependencies(driver
   rclcpp

--- a/epuck_ros2_cpp/src/driver.cpp
+++ b/epuck_ros2_cpp/src/driver.cpp
@@ -102,9 +102,8 @@ public:
     else
       mI2cMain = std::make_unique<I2CWrapperHW>("/dev/i2c-4");
     mTofInitialized = tofInit(4, 0x29, 1);
-    if (!mTofInitialized) {
+    if (!mTofInitialized)
       RCLCPP_WARN(get_logger(), "ToF device is not accessible!");
-    }
 
     // Initialize the values
     std::fill(mMsgActuators, mMsgActuators + MSG_ACTUATORS_SIZE, 0);

--- a/epuck_ros2_cpp/src/driver.cpp
+++ b/epuck_ros2_cpp/src/driver.cpp
@@ -23,7 +23,6 @@ extern "C" {
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include "vl53l0x/tof.h"
 }
 
 #include <algorithm>
@@ -33,6 +32,10 @@ extern "C" {
 #include <memory>
 #include <string>
 #include <vector>
+
+extern "C" {
+#include "vl53l0x/tof.h"
+}
 
 #include "epuck_ros2_cpp/i2c_wrapper.hpp"
 #include "geometry_msgs/msg/quaternion.hpp"
@@ -99,7 +102,7 @@ public:
       mI2cMain = std::make_unique<I2CWrapperTest>("/dev/i2c-4");
     else
       mI2cMain = std::make_unique<I2CWrapperHW>("/dev/i2c-4");
-    mTofInitialized = tofInit(0, 0x29, 4);
+    mTofInitialized = tofInit(4, 0x29, 1);
     if (!mTofInitialized) {
       RCLCPP_WARN(get_logger(), "ToF device is not accessible!");
     }
@@ -249,7 +252,7 @@ private:
       dist[i] = distance;
     }
     if (mTofInitialized) {
-      distTof = tofReadDistance() * 1000.0 + SENSOR_DIST_FROM_CENTER;
+      distTof = tofReadDistance() / 1000.0 + SENSOR_DIST_FROM_CENTER;
       ;
     }
 

--- a/epuck_ros2_cpp/src/driver.cpp
+++ b/epuck_ros2_cpp/src/driver.cpp
@@ -148,8 +148,8 @@ public:
       infraredTransform.header.frame_id = "base_link";
       infraredTransform.child_frame_id = "ps" + std::to_string(i);
       infraredTransform.transform.rotation = EPuckPublisher::euler2quaternion(0, 0, DISTANCE_SENSOR_ANGLE[i]);
-      infraredTransform.transform.translation.x = SENSOR_DIST_FROM_CENTER;
-      infraredTransform.transform.translation.y = 0;
+      infraredTransform.transform.translation.x = SENSOR_DIST_FROM_CENTER * cos(DISTANCE_SENSOR_ANGLE[i]);
+      infraredTransform.transform.translation.y = SENSOR_DIST_FROM_CENTER * sin(DISTANCE_SENSOR_ANGLE[i]);
       infraredTransform.transform.translation.z = 0;
       mInfraredBroadcasters[i]->sendTransform(infraredTransform);
     }
@@ -307,7 +307,7 @@ private:
       msgRange.header.frame_id = "tof";
       msgRange.radiation_type = sensor_msgs::msg::Range::INFRARED;
       msgRange.min_range = 0.005;
-      msgRange.min_range = 2.0;
+      msgRange.max_range = 2.0;
       msgRange.range = distTof;
       // Reference: https://forum.pololu.com/t/vl53l0x-beam-width-angle/11483/2
       msgRange.field_of_view = 25 * M_PI / 180;

--- a/epuck_ros2_cpp/src/driver.cpp
+++ b/epuck_ros2_cpp/src/driver.cpp
@@ -23,6 +23,7 @@ extern "C" {
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include "vl53l0x/tof.h"
 }
 
 #include <algorithm>
@@ -98,6 +99,7 @@ public:
       mI2cMain = std::make_unique<I2CWrapperTest>("/dev/i2c-4");
     else
       mI2cMain = std::make_unique<I2CWrapperHW>("/dev/i2c-4");
+    mTofInitialized = tofInit(0, 0x29, 4);
 
     // Initialize the values
     std::fill(mMsgActuators, mMsgActuators + MSG_ACTUATORS_SIZE, 0);
@@ -275,6 +277,9 @@ private:
       OUT_OF_RANGE,  // 135
       dist[4],       // 150
     };
+    if (mTofInitialized) {
+      msg.ranges[msg.ranges.size() / 2] = tofReadDistance() * 1000.0;
+    }
     mLaserPublisher->publish(msg);
 
     // Create Range messages
@@ -443,6 +448,8 @@ private:
 
   float mWheelDistance;
   float mWheelRadius;
+
+  int mTofInitialized;
 };
 
 int main(int argc, char *argv[]) {

--- a/epuck_ros2_cpp/src/driver.cpp
+++ b/epuck_ros2_cpp/src/driver.cpp
@@ -66,7 +66,7 @@ const float DEFAULT_WHEEL_DISTANCE = 0.05685;
 const float DEFAULT_WHEEL_RADIUS = 0.02;
 const float SENSOR_DIST_FROM_CENTER = 0.035;
 const std::vector<std::vector<float>> INFRARED_TABLE = {{0, 4095},      {0.005, 2133.33}, {0.01, 1465.73}, {0.015, 601.46},
-                                                        {0.02, 383.84}, {0.03, 234.93},   {0.04, 158.03}};
+                                                        {0.02, 383.84}, {0.03, 234.93},   {0.04, 158.03},  {0.05, 120}};
 const std::vector<double> DISTANCE_SENSOR_ANGLE = {
   -15 * M_PI / 180,   // ps0
   -45 * M_PI / 180,   // ps1
@@ -205,7 +205,7 @@ private:
 
   static float intensity2distance(int pX) {
     for (unsigned int i = 0; i < INFRARED_TABLE.size() - 1; i++) {
-      if (INFRARED_TABLE[i][1] >= pX && INFRARED_TABLE[i + 1][1] < pX) {
+      if (INFRARED_TABLE[i][1] > pX && INFRARED_TABLE[i + 1][1] <= pX) {
         const float bX = INFRARED_TABLE[i][1];
         const float bY = INFRARED_TABLE[i][0];
         const float aX = INFRARED_TABLE[i + 1][1];

--- a/epuck_ros2_cpp/src/driver.cpp
+++ b/epuck_ros2_cpp/src/driver.cpp
@@ -249,7 +249,7 @@ private:
       dist[i] = distance;
     }
     if (mTofInitialized) {
-      distTof = tofReadDistance() * 1000.0;
+      distTof = tofReadDistance() * 1000.0 + SENSOR_DIST_FROM_CENTER;;
     }
 
     // Create LaserScan message

--- a/epuck_ros2_cpp/src/driver.cpp
+++ b/epuck_ros2_cpp/src/driver.cpp
@@ -249,7 +249,8 @@ private:
       dist[i] = distance;
     }
     if (mTofInitialized) {
-      distTof = tofReadDistance() * 1000.0 + SENSOR_DIST_FROM_CENTER;;
+      distTof = tofReadDistance() * 1000.0 + SENSOR_DIST_FROM_CENTER;
+      ;
     }
 
     // Create LaserScan message

--- a/epuck_ros2_cpp/src/driver.cpp
+++ b/epuck_ros2_cpp/src/driver.cpp
@@ -250,9 +250,8 @@ private:
       float distance = EPuckPublisher::intensity2distance(distanceIntensity);
       dist[i] = distance;
     }
-    if (mTofInitialized) {
+    if (mTofInitialized)
       distTof = tofReadDistance() / 1000.0;
-    }
 
     // Create LaserScan message
     auto msg = sensor_msgs::msg::LaserScan();

--- a/epuck_ros2_cpp/src/driver.cpp
+++ b/epuck_ros2_cpp/src/driver.cpp
@@ -101,8 +101,8 @@ public:
       mI2cMain = std::make_unique<I2CWrapperTest>("/dev/i2c-4");
     else
       mI2cMain = std::make_unique<I2CWrapperHW>("/dev/i2c-4");
-    mTofInitialized = tofInit(4, 0x29, 1);
-    if (!mTofInitialized)
+    mTofInitStatus = tofInit(4, 0x29, 1);
+    if (!mTofInitStatus)
       RCLCPP_WARN(get_logger(), "ToF device is not accessible!");
 
     // Initialize the values
@@ -249,7 +249,7 @@ private:
       float distance = EPuckPublisher::intensity2distance(distanceIntensity);
       dist[i] = distance;
     }
-    if (mTofInitialized)
+    if (mTofInitStatus)
       distTof = tofReadDistance() / 1000.0;
 
     // Create LaserScan message
@@ -299,7 +299,7 @@ private:
       msgRange.field_of_view = 15 * M_PI / 180;
       mRangePublisher[i]->publish(msgRange);
     }
-    if (mTofInitialized) {
+    if (mTofInitStatus) {
       auto msgRange = sensor_msgs::msg::Range();
       msgRange.header.stamp = stamp;
       msgRange.header.frame_id = "tof";
@@ -468,7 +468,7 @@ private:
   float mWheelDistance;
   float mWheelRadius;
 
-  int mTofInitialized;
+  int mTofInitStatus;
 };
 
 int main(int argc, char *argv[]) {

--- a/epuck_ros2_cpp/test/test_driver.py
+++ b/epuck_ros2_cpp/test/test_driver.py
@@ -238,7 +238,7 @@ class TestController(unittest.TestCase):
             self.node,
             Range,
             'ps0',
-            lambda msg: abs(msg.range - 0.05 - DISTANCE_FROM_CENTER) < 1E-3)
+            lambda msg: abs(msg.range - 0.05) < 1E-3)
         self.assertTrue(
             condition, 'The node hasn\'t published any distance measurement')
 
@@ -247,7 +247,7 @@ class TestController(unittest.TestCase):
             self.node,
             Range,
             'ps1',
-            lambda msg: abs(msg.range - 0.02 - DISTANCE_FROM_CENTER) < 1E-3
+            lambda msg: abs(msg.range - 0.02) < 1E-3
         )
         self.assertTrue(
             condition, 'The node hasn\'t published any distance measurement')


### PR DESCRIPTION
**Description**
There is ToF (STM-VL53L0X) sensor on e-puck2. Messages from the sensor should be decoded and added to /scan topic. Also, the new topic /tof should also be created.

**Related Issues**
Closes #6 

**Tasks**
  - [x] Add VL53L0X library.
  - [x] Integrate ToF to LaserScan topic.
  - [x] Create new Range topic called `/tof`.
  - [x] Configure CI (ignore VL53L0X library).
  - [x] Verify the ToF measurements on e-puck2.
  - [x] Reduce range of distance sensors to 5cm (this still produces a lot of noise, but it doesn't make sense to go under that range)