### PR TITLE
Fix I2C device numbers

### DIFF
--- a/epuck_ros2_camera/src/pipuck_ov7670.c
+++ b/epuck_ros2_camera/src/pipuck_ov7670.c
@@ -15,7 +15,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#define I2C_CHANNEL 4
+#define I2C_CHANNEL 12
 #define OV7670_ADDR 0x21
 
 /*######################
@@ -96,7 +96,7 @@ int read_i2c(uint8_t reg, uint8_t *val) {
 }
 
 int pipuck_ov7670_init(void) {
-  sprintf(filename, "/dev/i2c-%d", 4);
+  sprintf(filename, "/dev/i2c-%d", I2C_CHANNEL);
   if ((file = open(filename, O_RDWR)) < 0) {
     /* ERROR HANDLING: you can check errno to see what went wrong */
     perror("Failed to open the i2c bus");

--- a/epuck_ros2_driver/scripts/read_i2c.py
+++ b/epuck_ros2_driver/scripts/read_i2c.py
@@ -42,7 +42,7 @@ def _get_params(buffer):
 
 while True:
     data = []
-    with open('/tmp/dev/i2c-4_write', 'rb') as f:
+    with open('/tmp/dev/i2c-12_write', 'rb') as f:
         data = list(f.read())
 
     if len(data) > 0 and prev_data != data:

--- a/epuck_ros2_driver/src/driver.cpp
+++ b/epuck_ros2_driver/src/driver.cpp
@@ -121,12 +121,12 @@ public:
 
     // Create I2C object
     if (type == "test")
-      mI2cMain = std::make_shared<I2CWrapperTest>("/dev/i2c-4");
+      mI2cMain = std::make_shared<I2CWrapperTest>("/dev/i2c-12");
     else
-      mI2cMain = std::make_shared<I2CWrapperHW>("/dev/i2c-4");
+      mI2cMain = std::make_shared<I2CWrapperHW>("/dev/i2c-12");
     mImu = std::make_shared<MPU9250>(mI2cMain);
     mImu->calibrate();
-    mTofInitStatus = tofInit(4, 0x29, 1);
+    mTofInitStatus = tofInit(12, 0x29, 1);
     if (!mTofInitStatus)
       RCLCPP_WARN(get_logger(), "ToF device is not accessible!");
 

--- a/epuck_ros2_driver/test/test_driver.py
+++ b/epuck_ros2_driver/test/test_driver.py
@@ -170,7 +170,7 @@ def generate_test_description():
     # Inital IMU data
     if not os.path.exists('/tmp/dev'):
         os.makedirs('/tmp/dev')
-    with open(f'/tmp/dev/i2c-4_read_' + str(0x68), 'w+b') as f:
+    with open(f'/tmp/dev/i2c-12_read_' + str(0x68), 'w+b') as f:
         f.write(bytearray([0] * 6))
 
     controller = launch_ros.actions.Node(
@@ -342,7 +342,7 @@ class TestController(unittest.TestCase):
         self.assertTrue(condition, 'Should move backward')
 
     def test_imu(self, launch_service, proc_output):
-        with open(f'/tmp/dev/i2c-4_read_' + str(0x68), 'w+b') as f:
+        with open(f'/tmp/dev/i2c-12_read_' + str(0x68), 'w+b') as f:
             f.write(bytearray([0]*6))
         time.sleep(MESSAGE_SEND_DELAY)
         condition = check_topic_condition(
@@ -353,7 +353,7 @@ class TestController(unittest.TestCase):
         )
         self.assertTrue(condition, 'IMU should publish zeros')
 
-        with open(f'/tmp/dev/i2c-4_read_' + str(0x68), 'w+b') as f:
+        with open(f'/tmp/dev/i2c-12_read_' + str(0x68), 'w+b') as f:
             f.write(bytearray([127, 0] * 3))
         time.sleep(MESSAGE_SEND_DELAY)
         condition = check_topic_condition(

--- a/epuck_ros2_driver/test/test_driver.py
+++ b/epuck_ros2_driver/test/test_driver.py
@@ -60,7 +60,7 @@ def int162arr(val):
     return arr
 
 
-def read_params_from_i2c(idx=4, address=0x1F):
+def read_params_from_i2c(idx=12, address=0x1F):
     params = {}
     for _ in range(READ_WRITE_RETRY_COUNT):
         with open(f'/tmp/dev/i2c-{idx}_write_' + str(address), 'r+b') as f:
@@ -74,7 +74,7 @@ def read_params_from_i2c(idx=4, address=0x1F):
     return params, []
 
 
-def write_params_to_i2c(params, idx=4, address=0x1F):
+def write_params_to_i2c(params, idx=12, address=0x1F):
     buffer = [0] * SENSORS_SIZE
 
     # Fill the buffer


### PR DESCRIPTION
The I2C device number is changed for the new e-pucks, see:
https://github.com/gctronic/Pi-puck/commit/bc50619edb4570116553a1203b7bf78f36b31c71